### PR TITLE
macOSの情報取得方法をsw_versコマンドに変更

### DIFF
--- a/darwin/get.go
+++ b/darwin/get.go
@@ -2,34 +2,22 @@ package darwin
 
 import (
 	//"fmt"
-	"os"
+	"os/exec"
+	"strings"
 
 	"github.com/Hayao0819/go-distro/ostype"
-	"howett.net/plist"
 )
 
-// macOSの詳細を返します
+// sw_versの出力結果からmacOSのProductVersionを返します
 func Get() ostype.F {
-	info := struct {
-		BuildID                   string `plist:"BuildID"`
-		ProductBuildVersion       string `plist:"ProductBuildVersion"`
-		ProductCopyright          string `plist:"ProductCopyright"`
-		ProductName               string `plist:"ProductName"`
-		ProductUserVisibleVersion string `plist:"ProductUserVisibleVersion"`
-		ProductVersion            string `plist:"ProductVersion"`
-		IOSSupportVersion         string `plist:"iOSSupportVersion"`
-	}{}
+	cmdstr := "sw_vers | grep ProductVersion | cut -f 3"
+	out, err := exec.Command("sh", "-c", cmdstr).Output()
 
-	sysxml, err := os.Open("/System/Library/CoreServices/SystemVersion.plist")
 	if err != nil {
 		return Other
 	}
-	decoder := plist.NewDecoder(sysxml)
-	if err := decoder.Decode(&info); err != nil {
-		return Other
-	}
-	//fmt.Println(sysxml)
-	//println(info.ProductVersion)
 
-	return getFromVersion(info.ProductVersion)
+	ProductVersion := strings.TrimSpace(string(out))
+
+	return getFromVersion(ProductVersion)
 }


### PR DESCRIPTION
issue #2 について，sw_versの出力結果から，ProductVersionを取得するように変更しました．
変更に伴う実行結果は以下のとおり，
```
$ go run ./cmd/main.go 
Detected Name     : macOS
Detected ID       : darwin
Detected CodeName : ventura
Supported Linux   : arch, debian, ubuntu, rhel, centos
Supported macOS   : Cheetah, Puma, Jaguar, Panther, Tiger, Leopard, Show Leopard, Lion, Mountain Lion, Mavericks, Yosemite, El Capitan, Serra, High Serra, Mojave, Catalina, Big Sur, Monterey, Ventura
```
元となるsw_versは以下のとおり，
```
$ sw_vers 
ProductName:            macOS
ProductVersion:         13.4.1
BuildVersion:           22F82
```
13.4.1 = ventura と正しく判定されていることを確認しました